### PR TITLE
fix(yandex,curl): fixed yandex v2, changes to curl

### DIFF
--- a/lua/pantran/curl.lua
+++ b/lua/pantran/curl.lua
@@ -12,7 +12,7 @@ local curl = {
 
 function curl:_spawn(request, path, data, callback)
   local cmd, stdout, response, handle = self.config.cmd, vim.loop.new_pipe(), ""
-  local args =vim.tbl_extend("keep", self.config.user_args, {
+  local args = vim.tbl_extend("keep", self.config.user_args, {
     "--fail-with-body",
     "--retry", self.config.retry,
     "--max-time", self.config.timeout,
@@ -22,9 +22,14 @@ function curl:_spawn(request, path, data, callback)
     tostring(self._url / path)
   })
 
-  for key, value in pairs(vim.tbl_extend("error", self._data, data)) do
-    table.insert(args, 1, ("%s=%s"):format(key, value))
-    table.insert(args, 1, "--data-urlencode")
+  if self._headers["Content-Type"] == "application/json" then
+    table.insert(args, 1, vim.json.encode(vim.tbl_extend("error", self._data, data)))
+    table.insert(args, 1, "--data")
+  else
+    for key, value in pairs(vim.tbl_extend("error", self._data, data)) do
+      table.insert(args, 1, ("%s=%s"):format(key, value))
+      table.insert(args, 1, "--data-urlencode")
+    end
   end
 
   for key, value in pairs(self._headers) do
@@ -118,7 +123,7 @@ end
 function curl.new(args)
   local self = {
     _url = curl.url(args.url),
-    _data = args.data or {},
+    _data = vim.tbl_extend("error", vim.empty_dict(), args.data or {}),
     _headers = args.headers or {},
     _static_paths = args.static_paths or {},
     _fmt_error = args.fmt_error or function(rsp) return tostring(rsp) end,

--- a/lua/pantran/curl.lua
+++ b/lua/pantran/curl.lua
@@ -23,7 +23,7 @@ function curl:_spawn(request, path, data, callback)
   })
 
   if self._headers["Content-Type"] == "application/json" then
-    table.insert(args, 1, vim.json.encode(vim.tbl_extend("error", self._data, data)))
+    table.insert(args, 1, vim.json.encode(vim.tbl_extend("error", vim.empty_dict(), self._data, data)))
     table.insert(args, 1, "--data")
   else
     for key, value in pairs(vim.tbl_extend("error", self._data, data)) do
@@ -123,7 +123,7 @@ end
 function curl.new(args)
   local self = {
     _url = curl.url(args.url),
-    _data = vim.tbl_extend("error", vim.empty_dict(), args.data or {}),
+    _data = args.data or {},
     _headers = args.headers or {},
     _static_paths = args.static_paths or {},
     _fmt_error = args.fmt_error or function(rsp) return tostring(rsp) end,

--- a/lua/pantran/engines/yandex.lua
+++ b/lua/pantran/engines/yandex.lua
@@ -17,7 +17,7 @@ local yandex = {
 }
 
 function yandex.detect(text)
-  local detected = yandex._api:post("detectLanguage", {
+  local detected = yandex._api:post("detect", {
     text = text,
   })
 
@@ -32,7 +32,7 @@ function yandex.languages()
     target = {}
   }
 
-  local langs = yandex._api:post("listLanguages").languages
+  local langs = yandex._api:post("languages").languages
   for _, lang in pairs(langs) do
     languages.source[lang.code] = lang.name
     languages.target[lang.code] = lang.name
@@ -71,10 +71,11 @@ function yandex.setup()
 
   yandex._api = curl.new{
     url = yandex.url,
-    static_paths = {"listLanguages"},
+    static_paths = {"languages"},
     fmt_error = function(response) return response.message end,
     headers = {
-      authorization = c.api_key and ("Api-Key %s"):format(c.api_key) or ("Bearer %s"):format(c.iam_token)
+      ["Content-Type"] = "application/json",
+      ["Authorization"] = c.api_key and ("Api-Key %s"):format(c.api_key) or ("Bearer %s"):format(c.iam_token)
     },
     data = {
       folderId = c.folder_id,


### PR DESCRIPTION
Yandex Translator API v2 wasn't working. This PR fixes that. Part of the problem was that the API accepts JSON (as i think), so now if any engine sets Content-Type header equal to "application/json", curl will create a request with a valid JSON body instead of passing data as plain parameters.