### PR TITLE
fix: switch to the correct window after ui close

### DIFF
--- a/lua/pantran/ui/init.lua
+++ b/lua/pantran/ui/init.lua
@@ -6,6 +6,8 @@ local config = require("pantran.config")
 local properties = require("pantran.utils.properties")
 local bufutils = require("pantran.utils.buffer")
 
+local origin_win = 0
+
 local ui = {
   config = {
     width_percentage = 0.6,
@@ -55,6 +57,7 @@ function ui:close()
   for _, win in pairs(self._win) do
     win:close()
   end
+  vim.api.nvim_set_current_win(origin_win)
 end
 
 function ui:resize()
@@ -175,6 +178,7 @@ function ui.prop.get:input()
 end
 
 function ui.new(engine, source, target, coords, text)
+  origin_win = vim.api.nvim_get_current_win()
   local win_coords = ui._compute_win_coords()
 
   local self = properties.make(setmetatable({

--- a/lua/pantran/ui/init.lua
+++ b/lua/pantran/ui/init.lua
@@ -176,7 +176,6 @@ function ui.prop.get:input()
 end
 
 function ui.new(engine, source, target, coords, text)
-  origin_win = vim.api.nvim_get_current_win()
   local win_coords = ui._compute_win_coords()
 
   local self = properties.make(setmetatable({

--- a/lua/pantran/ui/init.lua
+++ b/lua/pantran/ui/init.lua
@@ -6,8 +6,6 @@ local config = require("pantran.config")
 local properties = require("pantran.utils.properties")
 local bufutils = require("pantran.utils.buffer")
 
-local origin_win = 0
-
 local ui = {
   config = {
     width_percentage = 0.6,
@@ -57,7 +55,7 @@ function ui:close()
   for _, win in pairs(self._win) do
     win:close()
   end
-  vim.api.nvim_set_current_win(origin_win)
+  vim.api.nvim_set_current_win(self._origin_win)
 end
 
 function ui:resize()
@@ -191,6 +189,7 @@ function ui.new(engine, source, target, coords, text)
         translation = window.new(win_coords.translation),
         input = window.new(win_coords.input)
       },
+      _origin_win = vim.api.nvim_get_current_win(),
       coords = coords,
       previous = {} -- store for previous input, source, target, etc.
     }, {__index = ui}))


### PR DESCRIPTION
## Description
When working with multiple windows, the plugin would sometimes focus
the wrong window after closing the UI, causing replace/append operations to
affect incorrect windows. This change tracks and restores focus to the original working
window.

Tested in nvim 0.9.5, 0.10.2, nightly

## Problem demonstration
https://github.com/user-attachments/assets/9d5cd153-b6b6-4971-a3d2-265ed43f0fef

