### PR TITLE
fix(command): fix off-by-one error in visual mode

### DIFF
--- a/lua/pantran/handlers.lua
+++ b/lua/pantran/handlers.lua
@@ -8,7 +8,10 @@ end
 function handlers.replace(text, coords)
   local lines = vim.split(text, "\n", {plain = true})
   if coords then
-    vim.api.nvim_buf_set_text(0, coords.srow, coords.scol, coords.erow, coords.ecol + 1, lines)
+    if coords.ecol ~= 0 then
+      coords.ecol = coords.ecol + 1
+    end
+    vim.api.nvim_buf_set_text(0, coords.srow, coords.scol, coords.erow, coords.ecol, lines)
   else
     vim.api.nvim_put(lines, "l", true, false)
   end


### PR DESCRIPTION
This change fixes an error when calling `:‘<,’>Pantran mode=replace` if the last selected line in visual mode was empty.

```bash
Error executing vim.schedule lua callback: ...local/share/nvim/lazy/pantran.nvim/lua/pantran/async.lua:36
: ...al/share/nvim/lazy/pantran.nvim/lua/pantran/handlers.lua:14: Invalid 'end_col': out of range
stack traceback:
        [C]: in function 'nvim_buf_set_text'
        ...al/share/nvim/lazy/pantran.nvim/lua/pantran/handlers.lua:14: in function <...al/share/nvim/laz
y/pantran.nvim/lua/pantran/handlers.lua:8>
        ...cal/share/nvim/lazy/pantran.nvim/lua/pantran/command.lua:74: in function <...cal/share/nvim/la
zy/pantran.nvim/lua/pantran/command.lua:72>
stack traceback:
        [C]: in function 'error'
        ...local/share/nvim/lazy/pantran.nvim/lua/pantran/async.lua:36: in function ''
        vim/_editor.lua: in function <vim/_editor.lua:0>
```